### PR TITLE
put the rotation angle at -1.1 in hologram_center.txt

### DIFF
--- a/spectractor/extractor/dispersers/ronchi170lpmm/hologram_center.txt
+++ b/spectractor/extractor/dispersers/ronchi170lpmm/hologram_center.txt
@@ -1,2 +1,2 @@
 #x_center y_center theta_tilt_in_degree
-2000 2000 0
+2000 2000 -1.0523630837217959


### PR DESCRIPTION
simply put the rotation angle for the Ronchi170.

Then every spectra is well reconstructed without crash.

Sylvie