### PR TITLE
Lighter output

### DIFF
--- a/spectractor/astrometry.py
+++ b/spectractor/astrometry.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from copy import deepcopy
 import subprocess
 import shutil
@@ -153,7 +154,9 @@ def get_gaia_coords_after_proper_motion(gaia_catalog, date_obs):
                               np.array(gaia_catalog['dec']) * np.pi / 180),
                           pm_dec=gaia_catalog['pmdec'].filled(0),
                           distance=Distance(parallax=parallax * u.mas, allow_negative=True))
-    gaia_coords_after_proper_motion = gaia_stars.apply_space_motion(new_obstime=Time(date_obs))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*distance overridden.*", category=Warning)
+        gaia_coords_after_proper_motion = gaia_stars.apply_space_motion(new_obstime=Time(date_obs))
     return gaia_coords_after_proper_motion
 
 

--- a/spectractor/config.py
+++ b/spectractor/config.py
@@ -110,16 +110,19 @@ def load_config(config_filename, rebin=True):
     """
     my_logger = set_logger(__name__)
     mypath = os.path.dirname(__file__)
-    if not os.path.isfile(os.path.join(mypath, parameters.CONFIG_DIR, "default.ini")):
+    # Use the bundled config/ directory relative to this file, not parameters.CONFIG_DIR
+    # (parameters.CONFIG_DIR can be overwritten at runtime, e.g. by loading a spectrum FITS file)
+    config_dir = os.path.join(mypath, "config")
+    if not os.path.isfile(os.path.join(config_dir, "default.ini")):
         raise FileNotFoundError('Config file default.ini does not exist.')
     # Load the configuration file
-    from_config_to_parameters(os.path.join(mypath, parameters.CONFIG_DIR, "default.ini"))
+    from_config_to_parameters(os.path.join(config_dir, "default.ini"))
 
     if not os.path.isfile(config_filename):
-        if not os.path.isfile(os.path.join(mypath, parameters.CONFIG_DIR, config_filename)):
+        if not os.path.isfile(os.path.join(config_dir, config_filename)):
             raise FileNotFoundError(f'Config file {config_filename} does not exist.')
         else:
-            config_filename = os.path.join(mypath, parameters.CONFIG_DIR, config_filename)
+            config_filename = os.path.join(config_dir, config_filename)
     # Load the configuration file
     my_logger.info(f"\n\tLoading {config_filename} with {parameters.VERBOSE=}...")
     from_config_to_parameters(config_filename)
@@ -160,7 +163,7 @@ def load_config(config_filename, rebin=True):
         txt = ""
         # default.ini should be the config file with the most parameters
         config = configparser.ConfigParser()
-        config.read(os.path.join(mypath, parameters.CONFIG_DIR, "default.ini"))
+        config.read(os.path.join(config_dir, "default.ini"))
         for section in config.sections():
             txt += f"Section: {section}\n"
             for options in config.options(section):

--- a/spectractor/extractor/dispersers/HoloAmAg_7.5/NOTES
+++ b/spectractor/extractor/dispersers/HoloAmAg_7.5/NOTES
@@ -1,0 +1,6 @@
+- ratio_order_2over1.txt: fit of a model to Sylvie's data from CTIO spectra observed with a blue filter
+- transmission.txt: fit on CTIO data 2017/30/05 normalized with multispectra_Thor300_HD111980_CTIO_throughput_prod7.5.txt
+../CTIODataJune2017_reduced_RG715_v2_prod7.5/data_30may17_A2=0.1/multispectra_HoloAmAg_HD111980_HoloAmAg_throughput.txt
+(see jupyter notebook Multispectra.ipynb)
+- N.txt: interpolation of Neff estimated with CTIO scan of the hologram
+- hologram_*.txt: same

--- a/spectractor/extractor/dispersers/Thor300_7.5/NOTES
+++ b/spectractor/extractor/dispersers/Thor300_7.5/NOTES
@@ -1,0 +1,5 @@
+- ratio_order_2over1.txt: fit of a model to Sylvie's data from CTIO spectra observed with a blue filter
+- transmission.txt: model best fit on a mix of measurements coming from the Thorlabs data sheet (300-450nm), Laurent's measurement
+at DCCD=200mm (450-920nm), Arthur's measurement at DCCD=58mm (1000>920nm) and Thorlabs data sheet again (>1000nm)
+(see jupyter notebook Disperser_efficiencies.ipynb)
+- N.txt: estimation with CTIO data

--- a/spectractor/extractor/dispersers/blue300lpmm_qn1_old/NOTES
+++ b/spectractor/extractor/dispersers/blue300lpmm_qn1_old/NOTES
@@ -1,0 +1,1 @@
+Blue quad notch filter

--- a/spectractor/extractor/spectrum.py
+++ b/spectractor/extractor/spectrum.py
@@ -173,7 +173,7 @@ class Spectrum:
         Size of the spectrogram along the y axis.
     """
 
-    def __init__(self, file_name="", image=None, order=1, target=None, config="", fast_load=False,
+    def __init__(self, file_name="", image=None, order=1, target=None, config="", fast_load=True,
                  spectrogram_file_name_override=None,
                  psf_file_name_override=None,):
         """ Class used to store information and methods relative to spectra and their extraction.
@@ -633,6 +633,13 @@ class Spectrum:
             Path of the output fits file.
         overwrite: bool
             If True overwrite the output file if needed (default: False).
+            
+        NOTES
+        -----
+        - The spectrum is saved in the first extension of the fits file, with the wavelength array in the first column, the spectrum in the second column and the error in the third column.
+        - The header of the first extension contains the relevant parameters of the spectrum and its extraction.
+        - The config parameters are saved in the CONFIG extension of the fits file, and the lines table is saved in the LINES extension of the fits file.
+        - Only in DEBUG mode, the spectrogram data and the PSF table are saved in the fits file in the S_DATA and PSF_TAB extensions respectively.
 
         Examples
         --------
@@ -677,10 +684,12 @@ class Spectrum:
             hdu1.header[header_key] = value
             # print(f"Set header key {header_key} to {value} from attr {attribute}")
 
-        extnames = ["SPECTRUM", "SPEC_COV", "ORDER2", "ORDER0"]  # spectrum data
-        extnames += ["S_DATA", "S_ERR", "S_BGD", "S_BGD_ER", "S_FIT", "S_RES", "S_FLAT", "S_STAR", "S_MASK"]
-        extnames += ["PSF_TAB"]  # PSF parameter table
-        extnames += ["LINES"]  # spectroscopic line table
+        extnames = ["SPECTRUM", "SPEC_COV", "ORDER2"]  # spectrum data
+        if parameters.DEBUG:
+            extnames += ["ORDER0"]  # spectrum order0 timestamps
+            extnames += ["S_DATA", "S_ERR", "S_BGD", "S_BGD_ER", "S_FIT", "S_RES", "S_FLAT", "S_STAR", "S_MASK"]
+            extnames += ["PSF_TAB"]  # PSF parameter table
+            extnames += ["LINES"]  # spectroscopic line table
         extnames += ["CONFIG"]  # config parameters
         hdus = {"SPECTRUM": hdu1}
         for k, extname in enumerate(extnames):
@@ -821,7 +830,7 @@ class Spectrum:
         self.my_logger.info('\n\tSpectrogram saved in %s' % output_file_name)
 
     def load_spectrum(self, input_file_name, spectrogram_file_name_override=None,
-                      psf_file_name_override=None, fast_load=False):
+                      psf_file_name_override=None, fast_load=True):
         """Load the spectrum from a fits file (data, error and wavelengths).
 
         Parameters
@@ -833,7 +842,8 @@ class Spectrum:
         psf_file_name_override : str
             Manually specify a path to the psf file.
         fast_load: bool, optional
-            If True, only the spectrum is loaded (not the PSF nor the spectrogram data) (default: False).
+            If True, only the spectrum is loaded (not the PSF nor the spectrogram data) (default: True).
+            If False, load other hdus only in DEBUG mode.
 
         Examples
         --------
@@ -1093,11 +1103,11 @@ class Spectrum:
         if 'PSF_REG' in self.header and float(self.header["PSF_REG"]) > 0:
             self.chromatic_psf.opt_reg = float(self.header["PSF_REG"])
 
-        if not self.fast_load:
+        self.cov_matrix = hdu_list["SPEC_COV"].data
+        _, self.data_next_order, self.err_next_order = hdu_list["ORDER2"].data
+        if not self.fast_load and parameters.DEBUG:
             with (fits.open(input_file_name) as hdu_list):
                 # load other spectrum info
-                self.cov_matrix = hdu_list["SPEC_COV"].data
-                _, self.data_next_order, self.err_next_order = hdu_list["ORDER2"].data
                 self.target.image = hdu_list["ORDER0"].data
                 self.target.image_x0 = float(hdu_list["ORDER0"].header["IM_X0"])
                 self.target.image_y0 = float(hdu_list["ORDER0"].header["IM_Y0"])

--- a/spectractor/extractor/spectrum.py
+++ b/spectractor/extractor/spectrum.py
@@ -173,7 +173,7 @@ class Spectrum:
         Size of the spectrogram along the y axis.
     """
 
-    def __init__(self, file_name="", image=None, order=1, target=None, config="", fast_load=True,
+    def __init__(self, file_name="", image=None, order=1, target=None, config="", fast_load=False,
                  spectrogram_file_name_override=None,
                  psf_file_name_override=None,):
         """ Class used to store information and methods relative to spectra and their extraction.
@@ -634,13 +634,6 @@ class Spectrum:
         overwrite: bool
             If True overwrite the output file if needed (default: False).
             
-        NOTES
-        -----
-        - The spectrum is saved in the first extension of the fits file, with the wavelength array in the first column, the spectrum in the second column and the error in the third column.
-        - The header of the first extension contains the relevant parameters of the spectrum and its extraction.
-        - The config parameters are saved in the CONFIG extension of the fits file, and the lines table is saved in the LINES extension of the fits file.
-        - Only in DEBUG mode, the spectrogram data and the PSF table are saved in the fits file in the S_DATA and PSF_TAB extensions respectively.
-
         Examples
         --------
         >>> import os
@@ -685,11 +678,10 @@ class Spectrum:
             # print(f"Set header key {header_key} to {value} from attr {attribute}")
 
         extnames = ["SPECTRUM", "SPEC_COV", "ORDER2"]  # spectrum data
-        if parameters.DEBUG:
-            extnames += ["ORDER0"]  # spectrum order0 timestamps
-            extnames += ["S_DATA", "S_ERR", "S_BGD", "S_BGD_ER", "S_FIT", "S_RES", "S_FLAT", "S_STAR", "S_MASK"]
-            extnames += ["PSF_TAB"]  # PSF parameter table
-            extnames += ["LINES"]  # spectroscopic line table
+        extnames += ["ORDER0"]  # spectrum order0 timestamps
+        extnames += ["S_DATA", "S_ERR", "S_BGD", "S_BGD_ER", "S_FIT", "S_RES", "S_FLAT", "S_STAR", "S_MASK"]
+        extnames += ["PSF_TAB"]  # PSF parameter table
+        extnames += ["LINES"]  # spectroscopic line table
         extnames += ["CONFIG"]  # config parameters
         hdus = {"SPECTRUM": hdu1}
         for k, extname in enumerate(extnames):
@@ -830,7 +822,7 @@ class Spectrum:
         self.my_logger.info('\n\tSpectrogram saved in %s' % output_file_name)
 
     def load_spectrum(self, input_file_name, spectrogram_file_name_override=None,
-                      psf_file_name_override=None, fast_load=True):
+                      psf_file_name_override=None, fast_load=False):
         """Load the spectrum from a fits file (data, error and wavelengths).
 
         Parameters
@@ -842,8 +834,7 @@ class Spectrum:
         psf_file_name_override : str
             Manually specify a path to the psf file.
         fast_load: bool, optional
-            If True, only the spectrum is loaded (not the PSF nor the spectrogram data) (default: True).
-            If False, load other hdus only in DEBUG mode.
+            If True, only the spectrum is loaded (not the PSF nor the spectrogram data) (default: False).
 
         Examples
         --------
@@ -1103,10 +1094,10 @@ class Spectrum:
         if 'PSF_REG' in self.header and float(self.header["PSF_REG"]) > 0:
             self.chromatic_psf.opt_reg = float(self.header["PSF_REG"])
 
-        self.cov_matrix = hdu_list["SPEC_COV"].data
-        _, self.data_next_order, self.err_next_order = hdu_list["ORDER2"].data
-        if not self.fast_load and parameters.DEBUG:
+        if not self.fast_load:
             with (fits.open(input_file_name) as hdu_list):
+                self.cov_matrix = hdu_list["SPEC_COV"].data
+                _, self.data_next_order, self.err_next_order = hdu_list["ORDER2"].data
                 # load other spectrum info
                 self.target.image = hdu_list["ORDER0"].data
                 self.target.image_x0 = float(hdu_list["ORDER0"].header["IM_X0"])
@@ -1127,7 +1118,7 @@ class Spectrum:
                     if self.spectrogram_mask is not None:
                         self.spectrogram_mask = self.spectrogram_mask.astype(bool)
                 self.chromatic_psf.init_from_table(Table.read(hdu_list["PSF_TAB"]),
-                                                   saturation=self.spectrogram_saturation)
+                                                saturation=self.spectrogram_saturation)
                 self.lines.table = Table.read(hdu_list["LINES"], unit_parse_strict="silent")
 
     def load_spectrogram(self, input_file_name):  # pragma: no cover

--- a/spectractor/parameters.py
+++ b/spectractor/parameters.py
@@ -1,4 +1,5 @@
 import os
+import matplotlib as mpl
 import numpy as np
 
 # These parameters are the default values adapted to CTIO

--- a/spectractor/parameters.py
+++ b/spectractor/parameters.py
@@ -1,5 +1,4 @@
 import os
-import matplotlib as mpl
 import numpy as np
 
 # These parameters are the default values adapted to CTIO

--- a/spectractor/tools.py
+++ b/spectractor/tools.py
@@ -52,25 +52,6 @@ def _safe_tight_layout(self, *args, **kwargs):
 plt.Figure.tight_layout = _safe_tight_layout
 
 
-# Monkey-patch matplotlib tight_layout to handle LaTeX parsing errors
-# This is needed for matplotlib versions in LSST environment that don't fully support LaTeX
-_original_tight_layout = plt.Figure.tight_layout
-
-
-def _safe_tight_layout(self, *args, **kwargs):
-    """Wrapper for Figure.tight_layout that catches ValueError from LaTeX parsing errors."""
-    try:
-        return _original_tight_layout(self, *args, **kwargs)
-    except ValueError:
-        # Silently ignore LaTeX parsing errors in tight_layout
-        # This typically happens with Greek letters and complex math expressions
-        # in axis labels or titles when matplotlib's mathtext parser has issues
-        pass
-
-
-plt.Figure.tight_layout = _safe_tight_layout
-
-
 # do not increase speed:
 # @njit(fastmath=True, cache=True)
 def gauss(x, A, x0, sigma):
@@ -1896,11 +1877,11 @@ def plot_image_simple(ax, data, scale="lin", title="", units="Image units", cmap
         >>> if parameters.DISPLAY: plt.show()
     """
     if cmap is not None and isinstance(cmap, str):
-        colormap = copy.copy(cm.get_cmap(cmap))
+        colormap = copy.copy(matplotlib.colormaps[cmap])
     elif isinstance(cmap, matplotlib.colors.Colormap):
         colormap = cmap
     else:
-        colormap = copy.copy(cm.get_cmap('viridis'))
+        colormap = copy.copy(matplotlib.colormaps['viridis'])
     cmap_nan = copy.copy(colormap)
     cmap_nan.set_bad(color='lightgrey')
 


### PR DESCRIPTION
Save spectrogram, chromaticpsf and lines HDUs only in DEBUG mode. Load them only in DEBUG mode too.
Fast_load argument True by default
Use this branch to do a bit of other debugging

NO! spectrogram HDUs cannot be only for debugging because they are used by fit_spectrogram which is a normal call in the routine processing pipeline.