### PR TITLE
Fix error array rotation bug

### DIFF
--- a/spectractor/extractor/images.py
+++ b/spectractor/extractor/images.py
@@ -1071,7 +1071,7 @@ def find_target_init(image, guess, rotated=False, widths=[parameters.XWINDOW, pa
 
     if rotated:
         sub_image = np.copy(image.data_rotated[subYmin:subYmax, subXmin:subXmax])
-        sub_errors = np.copy(image.err[subYmin:subYmax, subXmin:subXmax])
+        sub_errors = np.copy(image.err_rotated[subYmin:subYmax, subXmin:subXmax])
     else:
         sub_image = np.copy(image.data[subYmin:subYmax, subXmin:subXmax])
         sub_errors = np.copy(image.err[subYmin:subYmax, subXmin:subXmax])


### PR DESCRIPTION
If the image is rotated, errors should be rotated too. Currently the `if rotated:` path draws on `image.err` rather than `image.err_rotated` (to go with `image.data_rotated`) as it should. This PR fixes it.